### PR TITLE
Add extended application information to applications()

### DIFF
--- a/R/applications.R
+++ b/R/applications.R
@@ -38,8 +38,19 @@ applications <- function(account = NULL) {
   # retreive applications
   apps <- lucid$applications(accountInfo$accountId)
   
-  # convert the list into a data frame with a subset of fields
-  res <- lapply(apps, `[`, c('name', 'url', 'status'))
+  # extract the subset of fields we're interested in 
+  res <- lapply(apps, `[`, c('name', 'url', 'status', 'created_time', 
+                             'updated_time', 'properties'))
+  
+  # promote the size and instance data to first-level fields
+  res <- lapply(res, function(x) { 
+    x$size <- x$properties$containers.template
+    x$instances <- x$properties$containers.count
+    x$properties <- NULL
+    return(x)
+  })
+  
+  # convert to data frame
   res <- do.call(rbind, res)
 
   as.data.frame(res, stringsAsFactors = FALSE)


### PR DESCRIPTION
This adds a few fields to the data frame returned by `applications()`, with the goal of driving the RStudio UI that will be built to provide a front-end to the package. In particular:
- The created/updated dates, to show the time of last deployment. 
- The size and instance information, to show initial values so the user knows if they're scaling up or down and by how much.

If you feel that this clutters the output too much, we could move it to another function that outputs more extensive information while `applications()` continues to return more basic data. 
