### PR TITLE
Support for user-supplied browser in deployApp

### DIFF
--- a/R/deployApp.R
+++ b/R/deployApp.R
@@ -116,8 +116,10 @@ deployApp <- function(appDir = getwd(),
                  application$url)
     
   # launch the browser if requested
-  if (launch.browser)
+  if (isTRUE(launch.browser))
     utils::browseURL(application$url)
+  else if (is.function(launch.browser))
+    launch.browser(application$url)
   
   # successful deployment!
   invisible(TRUE)


### PR DESCRIPTION
This change makes it possible to launch a browser of the user's choice when the deployment is completed, if `launch.browser` is set to a function rather than `TRUE`/`FALSE`. 
