### PR TITLE
emit all error messages about invalid dependencies at once

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -44,6 +44,8 @@ createAppManifest <- function(appDir, files, users) {
    
   # provide package entries for all dependencies
   packages <- list()
+  # potential error messages
+  msg      <- NULL
   for (pkg in dirDependencies(appDir)) {
     
     # get the description
@@ -51,17 +53,18 @@ createAppManifest <- function(appDir, files, users) {
   
     # if description is NA, application dependency may not be installed 
     if (is.na(description)) {
-      stop("Application depends on package \"", pkg, "\" but it is not",
-           " installed. Please resolve before continuing.",
-           call. = FALSE)
+      msg <- c(msg, paste("Application depends on package \"", pkg, "\" but it is not",
+                          " installed. Please resolve before continuing.", sep = ""))
+      next
     }
     
-    # validate the repository (will throw an error if there is a problem)
-    validateRepository(pkg, getRepository(description[[1]]))
+    # validate the repository (returns an error message if there is a problem)
+    msg <- c(msg, validateRepository(pkg, getRepository(description[[1]])))
     
     # good to go
     packages[[pkg]] <- description
   }
+  if (length(msg)) stop(paste(formatUL(msg, '\n*'), collapse = '\n'), call. = FALSE)
 
   # provide checksums for all files
   filelist <- list()
@@ -143,7 +146,7 @@ validateRepository <- function(pkg, repository) {
                         "install.packages('devtools'); ",
                         "devtools::install_github('devtools')\n", sep="")
     }
-    stop(msg, call. = FALSE)
+    msg
   }
 }
 


### PR DESCRIPTION
I find it a bit annoying when the number of dependencies is large, and many of them were installed from local source, because I will have to repeat the cycle of "deploy -> fail -> install -> redeploy -> fail again -> install...". Therefore I prefer `createAppManifest()` telling me all the unqualified packages at once.

Now the error message will be like this:

```
Preparing to deploy application...DONE
Uploading application bundle...Error: 
* Unable to deploy package dependency 'shiny'

  The package was installed locally from source. Only packages
  installed from CRAN or GitHub are supported.

* Unable to deploy package dependency 'formatR'

  The package was installed locally from source. Only packages
  installed from CRAN or GitHub are supported.
Execution halted
```
