### PR TITLE
assume .R and .Rmd are UTF8 encoded when parsing for dependencies

### DIFF
--- a/R/dependencies.R
+++ b/R/dependencies.R
@@ -97,7 +97,8 @@ fileDependencies <- function(file) {
     if (require(knitr, quietly = TRUE)) {
       purled <- ""
       purled_con <- textConnection("purled", open = "w", local = TRUE)
-      knitr::purl(file, purled_con, quiet = TRUE, documentation = 0)
+      knitr::purl(file, purled_con, quiet = TRUE, documentation = 0,
+                  encoding = checkEncoding(file))
       close(purled_con)
       input <- textConnection(purled, open = "r") 
       # rmarkdown is an implicit dependency (it's not referenced in the Rmd source)
@@ -110,7 +111,8 @@ fileDependencies <- function(file) {
     }    
   } else if (identical(ext, "r")) {
     # if this is an R script, we can parse its output directly
-    input <- file
+    input <- base::file(file, encoding = checkEncoding(file))
+    on.exit(close(input), add = TRUE)
   } else {
     # if it's not an extension we know, emit a warning
     warning("Could not determine dependencies for ", file, 
@@ -119,7 +121,7 @@ fileDependencies <- function(file) {
   }
   
   # parse file and examine expressions
-  exprs <- parse(input, n = -1L) 
+  exprs <- parse(input, n = -1L, encoding = checkEncoding(file))
   for (i in seq_along(exprs))
     pkgs <- append(pkgs, expressionDependencies(exprs[[i]]))
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -92,3 +92,17 @@ hr <- function(message = "", n = 80) {
     cat(hr, sep="", '\n')
   }
 }
+
+# this function was defined in the shiny package; in the unlikely event that
+# shiny:::checkEncoding() is not available, use a simplified version here
+checkEncoding <- tryCatch(
+  getFromNamespace('checkEncoding', 'shiny'),
+  error = function(e) {
+    function(file) {
+      if (.Platform$OS.type != 'windows') return('UTF-8')
+      x <- readLines(file, encoding = 'UTF-8', warn = FALSE)
+      isUTF8 <- !any(is.na(iconv(x, 'UTF-8')))
+      if (isUTF8) 'UTF-8' else getOption('encoding')
+    }
+  }
+)


### PR DESCRIPTION
so that apps under Windows can work with the development version of shiny
