### PR TITLE
lint: add support for single-file apps

### DIFF
--- a/R/lint-framework.R
+++ b/R/lint-framework.R
@@ -88,6 +88,7 @@ lint <- function(project) {
   satisfiedLayouts <- c(
     shinyAndUi = all(c("server.r", "ui.r") %in% appFilesBase),
     shinyAndIndex = "server.r" %in% appFilesBase && "index.html" %in% wwwFiles,
+    app = "app.r" %in% appFilesBase,
     Rmd = any(grepl(glob2rx("*.rmd"), appFilesBase))
   )
   


### PR DESCRIPTION
This adds support for single-file apps, which are available as of Shiny v0.10.1.9002.
