### PR TITLE
Handle windows paths with both forward and backward slashes.

### DIFF
--- a/R/lint-utils.R
+++ b/R/lint-utils.R
@@ -4,7 +4,7 @@ stripComments <- function(content) {
 
 hasAbsolutePaths <- function(content) {
   regex <- c(
-    "[\'\"]\\s*[a-zA-Z]:/[^\"\']", ## windows-style absolute paths
+    "[\'\"]\\s*[a-zA-Z]:[\\\\/][^\"\']", ## windows-style absolute paths
     "[\'\"]\\s*\\\\\\\\", ## windows UNC paths
     "[\'\"]\\s*/(?!/)(.*?)/(.*?)", ## unix-style absolute paths
     "[\'\"]\\s*~/", ## path to home directory

--- a/tests/testthat/shinyapp-with-absolute-paths/server.R
+++ b/tests/testthat/shinyapp-with-absolute-paths/server.R
@@ -12,7 +12,8 @@ shinyServer(function(input, output) {
   output$distPlot <- renderPlot({
     
     # read a file on disk
-    file <- read.table("C:/results.txt")
+    file <- read.table("C:\\results.txt")
+    fileForward <- read.table("C:/results.txt")
     otherFile <- read.table("/usr/local/files/files.txt")
     anotherFile <- readLines('../../foo.bar')
     serverFile <- "\\server\path\to\file"

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -8,10 +8,10 @@ test_that("linter warns about absolute paths and relative paths", {
   printLinterResults(result)
   
   absPathLintedIndices <- result[[serverPath]]$absolute.paths$indices
-  expect_identical(as.numeric(absPathLintedIndices), c(15, 16, 18))
+  expect_identical(as.numeric(absPathLintedIndices), c(15, 16, 17, 19))
   
   relPathLintedIndices <- result[[serverPath]]$invalid.relative.paths$indices
-  expect_identical(as.numeric(relPathLintedIndices), 17)
+  expect_identical(as.numeric(relPathLintedIndices), 18)
   
 })
 


### PR DESCRIPTION
The linting code had a bug where it did not correctly detect windows paths with backslashes (as is the norm in windows).  I realize that R allows you to have forward slashes in paths as well, but you should probably detect both.

I added a test line for both cases, and updated the tests as well.
