### PR TITLE
Support all forms of tilde expansion

### DIFF
--- a/R/lint-utils.R
+++ b/R/lint-utils.R
@@ -7,7 +7,7 @@ hasAbsolutePaths <- function(content) {
     "[\'\"]\\s*[a-zA-Z]:[\\\\/][^\"\']", ## windows-style absolute paths
     "[\'\"]\\s*\\\\\\\\", ## windows UNC paths
     "[\'\"]\\s*/(?!/)(.*?)/(.*?)", ## unix-style absolute paths
-    "[\'\"]\\s*~/", ## path to home directory
+    "[\'\"]\\s*~", ## path to home directory
     "\\[(.*?)\\]\\(\\s*[a-zA-Z]:/[^\"\']", ## windows-style markdown references [Some image](C:/...)
     "\\[(.*?)\\]\\(\\s*/", ## unix-style markdown references [Some image](/Users/...)
     NULL ## so we don't worry about commas above

--- a/R/lint.R
+++ b/R/lint.R
@@ -1,0 +1,53 @@
+#' @export
+lint <- function(filename, line_number = 1L, column_number = NULL, type = "style", message = "", line = "", ranges = NULL) {
+  structure(
+    list(
+      filename = filename,
+      line_number = line_number,
+      column_number = column_number %||% 1L,
+      type = type,
+      message = message,
+      line = line,
+      ranges = ranges
+      ),
+    class="lint")
+}
+
+#' @export
+print.lint <- function(x, ...) {
+
+  color <- switch(x$type,
+    "warning" = magenta,
+    "error" = red,
+    "style" = blue,
+    bold
+  )
+
+  message(
+    bold(x$filename, ":",
+    as.character(x$line_number), ":",
+    as.character(x$column_number), ": ", sep = ""),
+    color(x$type, ": ", sep = ""),
+    bold(x$message), "\n",
+    x$line, "\n",
+    highlight_string(x$column_number, x$ranges)
+    )
+}
+
+highlight_string <- function(column_number = NULL, ranges = NULL) {
+  maximum = max(column_number, unlist(ranges))
+
+  line <- fill_with(" ", maximum)
+
+  lapply(ranges, function(range) {
+    substr(line, range[1], range[2]) <<- fill_with("~", range[2] - range[1] + 1L)
+    })
+
+  substr(line, column_number, column_number + 1L) <- "^"
+
+  line
+}
+
+fill_with <- function(character = " ", length = 1L) {
+  paste0(collapse = "", rep.int(character, length))
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -132,3 +132,7 @@ rstudioEncoding <- function(dir) {
   enc <- drop(readDcf(proj, 'Encoding'))
   enc[!is.na(enc)]
 }
+
+`%||%` <- function(x, y) {
+  if(is.null(x)) { x } else { y }
+}

--- a/tests/testthat/shinyapp-with-absolute-paths/server.R
+++ b/tests/testthat/shinyapp-with-absolute-paths/server.R
@@ -19,6 +19,9 @@ shinyServer(function(input, output) {
     serverFile <- "\\server\path\to\file"
     validWeblink <- "//www.google.com/"
 
+    text_file <- file.path("~/home/file.txt"),
+    user_text_file <- file.path("~user.name/home/file.txt"),
+
     # generate bins based on input$bins from ui.R
     x    <- faithful[, 2]
     bins <- seq(min(x), max(x), length.out = input$bins + 1)

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -8,7 +8,7 @@ test_that("linter warns about absolute paths and relative paths", {
   printLinterResults(result)
   
   absPathLintedIndices <- result[[serverPath]]$absolute.paths$indices
-  expect_identical(as.numeric(absPathLintedIndices), c(15, 16, 17, 19))
+  expect_identical(as.numeric(absPathLintedIndices), c(15, 16, 17, 19, 22, 23))
   
   relPathLintedIndices <- result[[serverPath]]$invalid.relative.paths$indices
   expect_identical(as.numeric(relPathLintedIndices), 18)


### PR DESCRIPTION
The previous regex did not correctly identify all forms of possible tilde expansion.  http://www.gnu.org/software/bash/manual/html_node/Tilde-Expansion.html

Particularly the form `~fred/foo` would not have matched.
I added a test case as well as fixed the regex.