### PR TITLE
Ignore ds_store and gitignore files

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -19,6 +19,8 @@ bundleApp <- function(appDir) {
   files <- files[!grepl(glob2rx(".git/*"), files)]
   files <- files[!grepl(glob2rx(".Rproj.user/*"), files)]
   files <- files[!grepl(glob2rx("*.Rproj"), files)]
+  files <- files[!grepl(glob2rx(".DS_Store"), files)]
+  files <- files[!grepl(glob2rx(".gitignore"), files)]
   
   # copy the files into the bundle dir
   for (file in files) {


### PR DESCRIPTION
Files like `.DS_Store` and `.gitignore` should prob be ignored as they have no use for shinyapps and just make the bundles slightly larger. 
