### PR TITLE
Detect locale 

### DIFF
--- a/R/bundle.R
+++ b/R/bundle.R
@@ -110,6 +110,7 @@ createAppManifest <- function(appDir, files, users) {
   # create the manifest
   manifest <- list()
   manifest$version <- 1
+  manifest$locale <- getOption('shinyapps.locale', detectLocale())
   manifest$platform <- paste(R.Version()$major, R.Version()$minor, sep=".") 
   
   # if there are no packages set manifes$packages to NA (json null)

--- a/R/locale.R
+++ b/R/locale.R
@@ -1,0 +1,62 @@
+detectLocale <- function () {
+  sysName <- Sys.info()[['sysname']]
+  if (identical(sysName, "Windows")) {
+    locale <- detectLocale.Windows()
+  } else {
+    locale <- detectLocale.Unix()
+  }
+  
+  return(locale)
+}
+
+detectLocale.Unix <- function () {
+  unlist(strsplit(Sys.getlocale("LC_CTYPE"), ".", fixed=TRUE))[1]
+}
+
+detectLocale.Windows <- function (useCache = 
+                                  getOption('shinyapps.locale.cache', TRUE)) {
+  
+  cacheFile <- localeCacheFile()
+  if (file.exists(cacheFile) && useCache) {
+    
+    # get chached
+    cache <- as.list(readDcf(cacheFile, all=TRUE))  
+    
+    locale <- unlist(cache$locale)
+    
+  } else {
+    
+    # get system locale
+    locale <- systemLocale()
+    
+    # write the user info
+    write.dcf(list(locale = locale),
+              cacheFile,
+              width = 100)
+  }
+  
+  return(locale)
+}
+
+localeCacheFile <- function() {
+  normalizePath(file.path(shinyappsConfigDir(), "locale.dcf"), mustWork = FALSE)
+}
+
+systemLocale <- function() {
+  message("Detecting system locale ... ", appendLF = FALSE)
+  
+  # get system locale
+  info <- systemInfo()
+  raw <- as.character(info$System.Locale)
+  parts <- strsplit(unlist(strsplit(raw, ";",  fixed=TRUE)), "-", fixed=TRUE)
+  
+  # normalize locale to something like en_US
+  locale <- paste(tolower(parts[[1]][1]), toupper(parts[[1]][2]), sep="_")
+  
+  message(locale)
+  invisible(locale)
+}
+
+systemInfo <- function () {
+  info <- read.csv(textConnection(system("systeminfo /FO csv", intern=TRUE, wait=TRUE)))
+}

--- a/R/locale.R
+++ b/R/locale.R
@@ -5,7 +5,6 @@ detectLocale <- function () {
   } else {
     locale <- detectLocale.Unix()
   }
-  
   return(locale)
 }
 

--- a/man/options.Rd
+++ b/man/options.Rd
@@ -21,6 +21,8 @@ Supported global options include:
    \item{\code{shinyapps.http.trace}}{When \code{TRUE}, trace http calls (prints the method, path, and total milliseconds for each http request)}
    \item{\code{shinyapps.http.verbose}}{When \code{TRUE}, print verbose output for http connections (useful only for debugging SSL certificate or http connection problems)}
    \item{\code{shinyapps.launch.browser}}{When \code{TRUE}, automatically launch a browser to view applications after they are deployed}
+   \item{\code{shinyapps.locale.cache}}{When \code{FALSE}, disable the detected locale cache (Windows only). }
+   \item{\code{shinyapps.locale}}{Override the detected locale. }
 }
 }
 


### PR DESCRIPTION
This PR adds the ability to detect and normalize locale information and include it in the manifest. Windows support is a little hairy and uses the `systeminfo.exe` program capture the locale (rather then using native code). This is slow so its cached. (The cache can be invalidated via the `shinyapps.locale.cache` option.

Also locale information can be overridden via the `shinyapps.locale` option.